### PR TITLE
Search on graph with incomparable ID types

### DIFF
--- a/graph/__init__.py
+++ b/graph/__init__.py
@@ -328,9 +328,10 @@ def shortest_path(graph, start, end):
     for n1, n2, dist in graph.edges():
         g[n1].append((dist, n2))
 
-    q, visited, mins = [(0, start, ())], set(), {start: 0}
+    q, visited, mins = [(0, 0, start, ())], set(), {start: 0}
+    i = 1
     while q:
-        (cost, v1, path) = heappop(q)
+        (cost, _, v1, path) = heappop(q)
         if v1 not in visited:
             visited.add(v1)
             path = (v1, path)
@@ -350,7 +351,8 @@ def shortest_path(graph, start, end):
                 next_node = cost + dist
                 if prev is None or next_node < prev:
                     mins[v2] = next_node
-                    heappush(q, (next_node, v2, path))
+                    heappush(q, (next_node, i, v2, path))
+                    i += 1
     return float("inf"), []
 
 

--- a/graph/__init__.py
+++ b/graph/__init__.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, deque
 from functools import lru_cache
 from heapq import heappop, heappush
 from itertools import combinations
@@ -361,34 +361,21 @@ def breadth_first_search(graph, start, end):
     :param end: end node
     :return: path
     """
-    g = defaultdict(list)
-    for n1, n2, dist in graph.edges():
-        g[n1].append((dist, n2))
-
-    q, visited, mins = [(0, start, ())], set(), {start: 0}
+    visited = {start: None}
+    q = deque([start])
     while q:
-        (cost, v1, path) = heappop(q)
-        if v1 not in visited:
-            visited.add(v1)
-            path = (v1, path)
-
-            if v1 == end:  # exit criteria.
-                L = []
-                while path:
-                    v, path = path[0], path[1]
-                    L.append(v)
-                L.reverse()
-                return cost, L  # <-- exit if end is found.
-
-            for dist, v2 in g.get(v1, ()):
-                if v2 in visited:
-                    continue
-                prev = mins.get(v2, None)
-                next_node = cost + 1
-                if prev is None or next_node < prev:
-                    mins[v2] = next_node
-                    heappush(q, (next_node, v2, path))
-    return float("inf"), []  # <-- exit if end is not found.
+        node = q.popleft()
+        if node == end:
+            path = deque()
+            while node is not None:
+                path.appendleft(node)
+                node = visited[node]
+            return list(path)
+        for next_node in graph.nodes(from_node=node):
+            if next_node not in visited:
+                visited[next_node] = node
+                q.append(next_node)
+    return []
 
 
 def depth_first_search(graph, start, end):
@@ -1101,8 +1088,8 @@ def all_paths(graph, start, end):
 def degree_of_separation(graph, n1, n2):
     """ Calculates the degree of separation between 2 nodes."""
     assert n1 in graph.nodes()
-    d, p = breadth_first_search(graph, n1, n2)
-    return d
+    p = breadth_first_search(graph, n1, n2)
+    return len(p)-1
 
 
 def loop(graph, start, mid, end=None):

--- a/graph/transshipment_problem.py
+++ b/graph/transshipment_problem.py
@@ -262,7 +262,7 @@ def find_perfect_circuit(graph, start, jobs):
 
     new_starts = [B for A, B in jobs if A == start]
     for A in new_starts:
-        _, p = g.breadth_first_search(A, start)  # path back to start.
+        p = g.breadth_first_search(A, start)  # path back to start.
         if p:
             return [start] + p
     return []

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -435,3 +435,28 @@ def test_avoids():
     g = graph4x4()
     p = Graph.avoids(g, 1, 16, (3, 7, 11, 10))
     assert p == [1, 5, 9, 13, 14, 15, 16], p
+
+
+def test_incomparable_path_searching():
+    """
+    incomparable type A -> incomparable type A -> incomparable type B
+    |
+    v
+    incomparable type C
+    """
+    g = Graph()
+    g.add_edge(("A", "6"), ("B", "7"))
+    g.add_edge(("A", "6"), 6)
+    g.add_edge(("B", "7"), "B")
+
+    p = g.all_paths(("A", "6"), "B")
+    assert p == [[("A", "6"), ("B", "7"), "B"]]
+
+    p = g.depth_first_search(("A", "6"), "B")
+    assert p == [("A", "6"), ("B", "7"), "B"]
+
+    p = g.breadth_first_search(("A", "6"), "B")
+    assert p == (2, [("A", "6"), ("B", "7"), "B"])
+
+    p = g.shortest_path(("A", "6"), "B")
+    assert p == (2, [("A", "6"), ("B", "7"), "B"])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -426,7 +426,7 @@ def test_degree_of_separation():
 def test_loop():
     g = graph4x4()
     p = Graph.loop(g, 1, 16)
-    assert p == [1, 2, 3, 4, 8, 12, 16, 15, 11, 7, 6, 5, 1]
+    assert p == [1, 2, 3, 4, 8, 12, 16, 15, 14, 13, 9, 5, 1]
 
 
 def test_avoids():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -166,12 +166,10 @@ def test_distance():
 
 def test_bfs():
     g = graph03()
-    d, path = g.breadth_first_search(1, 7)
-    assert d == 2, d
+    path = g.breadth_first_search(1, 7)
     assert path == [1, 3, 7], path
 
-    d, path = g.breadth_first_search(1, 900)  # 900 doesn't exit.
-    assert d == float('inf')
+    path = g.breadth_first_search(1, 900)  # 900 doesn't exit.
     assert path == []
 
 
@@ -456,7 +454,7 @@ def test_incomparable_path_searching():
     assert p == [("A", "6"), ("B", "7"), "B"]
 
     p = g.breadth_first_search(("A", "6"), "B")
-    assert p == (2, [("A", "6"), ("B", "7"), "B"])
+    assert p == [("A", "6"), ("B", "7"), "B"]
 
     p = g.shortest_path(("A", "6"), "B")
     assert p == (2, [("A", "6"), ("B", "7"), "B"])

--- a/tests/test_spatial_graph.py
+++ b/tests/test_spatial_graph.py
@@ -122,8 +122,7 @@ def test_bfs():
     g = fishbone_graph()
     entry_point = (-1, 0, 2)
     exit_point = (-1, 0, 1)
-    d, p = g.breadth_first_search(entry_point, exit_point)
-    assert d == 3, d
+    p = g.breadth_first_search(entry_point, exit_point)
     assert len(p) == 4, p
 
 
@@ -139,8 +138,7 @@ def test_distance_from_path():
     g = fishbone_graph()
     entry_point = (-1, 0, 2)
     exit_point = (-1, 0, 1)
-    d, p = g.breadth_first_search(entry_point, exit_point)
-    assert d == 3
+    p = g.breadth_first_search(entry_point, exit_point)
     assert len(p) == 4
     assert g.distance_from_path(p) == 3
 
@@ -158,10 +156,10 @@ def test_subgraph_from_nodes():
     g = fishbone_graph()
     entry_point = (-1, 0, 2)
     exit_point = (-1, 0, 1)
-    d, p = g.breadth_first_search(entry_point, exit_point)
+    p = g.breadth_first_search(entry_point, exit_point)
     subgraph = g.subgraph_from_nodes(p)
     assert isinstance(subgraph, Graph3D), type(subgraph)
-    new_d, new_p = subgraph.breadth_first_search(entry_point, exit_point)
+    new_p = subgraph.breadth_first_search(entry_point, exit_point)
     assert p == new_p, (p, new_p)
 
 


### PR DESCRIPTION
It seems like a design flaw if searching depends on node IDs being comparable with each other (or maybe it's just a bug). This repo doesn't allow issues, so here's a failing test (until the searching is updated).

Anything that uses heapq (e.g. shortest_path) will error on nodes with IDs that can't be compared.

update: BFS now replaced with one that isn't a clone of shortest_path and doesn't use a heap. I guess if that's problematic for some reason, you can always use the same modification as was made to shortest_path instead.
update: shortest_path now uses insertion order as the second heapq value component.