### PR TITLE
For unsolvable graphs, raise exceptions rather than failing on poppin…

### DIFF
--- a/graph/traffic_scheduling_problem.py
+++ b/graph/traffic_scheduling_problem.py
@@ -30,8 +30,10 @@ def jam_solver(graph, loads, timeout=None):
     for method in methods:
         try:
             moves = method(graph, loads, timeout)
-        except TimeoutError:
-            pass
+        except (TimeoutError, Exception) as e:
+            if isinstance(e, Exception):
+                assert str(e) == "No solution found", f"{e} instead of No solution found"
+            continue
         if moves:
             return moves
     return moves
@@ -164,6 +166,8 @@ def bi_directional_progressive_bfs(graph, loads, timeout=None):
         timer.timeout_check()
 
         # forward
+        if not forward_queue:
+            raise Exception("No solution found")
         state = forward_queue.pop(0)
         occupied = {i[1] for i in state}
         for load_id, location in state:
@@ -193,6 +197,8 @@ def bi_directional_progressive_bfs(graph, loads, timeout=None):
                     break
 
         # backwards
+        if not reverse_queue:
+            raise Exception("No solution found")
         state = reverse_queue.pop(0)
         occupied = {i[1] for i in state}
         for load_id, location in state:
@@ -255,6 +261,8 @@ def bi_directional_bfs(graph, loads, timeout=None):
         timer.timeout_check()
 
         # forward
+        if not forward_queue:
+            raise Exception("No solution found")
         state = forward_queue.pop(0)
         occupied = {i[1] for i in state}
         for load_id, location in state:
@@ -274,6 +282,8 @@ def bi_directional_bfs(graph, loads, timeout=None):
                     break
 
         # backwards
+        if not reverse_queue:
+            raise Exception("No solution found")
         state = reverse_queue.pop(0)
         occupied = {i[1] for i in state}
         for load_id, location in state:
@@ -345,7 +355,7 @@ def pure_hill_climbing_algorithm(graph, loads, timeout=None):
                     solved = True
                     break
         if not states:
-            return None  # hill climbing doesn't lead to a solution.
+            raise Exception("No solution found")  # hill climbing doesn't lead to a solution
 
     steps, best_path = movements.shortest_path(initial_state, final_state)
     moves = path_to_moves(best_path)

--- a/graph/traffic_scheduling_problem.py
+++ b/graph/traffic_scheduling_problem.py
@@ -70,8 +70,10 @@ def check_user_input(graph, loads):
     for load_id, path in loads.items():
         if len(path) > 1:
             if not graph.has_path(path):
-                _, path = graph.shortest_path(path[0], path[-1])
-                loads[load_id] = path
+                _, new_path = graph.shortest_path(path[0], path[-1])
+                if not new_path:
+                    raise ValueError(f"No path found between {path[0]} and {path[-1]}")
+                loads[load_id] = new_path
 
 
 def path_to_moves(path):

--- a/tests/test_traffic_scheduling_problem.py
+++ b/tests/test_traffic_scheduling_problem.py
@@ -371,3 +371,18 @@ def test_simple_failed_path():
 
     assert sequence is None
 
+def test_incomplete_graph():
+    """ two loads with an incomplete graph making the problem unsolvable """
+    g = Graph()
+    for s, e in [(1, 2), (2, 3)]:
+        g.add_edge(s, e, 1, bidirectional=True)
+
+    loads = {1: [1, 5], 2: [5, 1]}
+    g.add_node(5)
+
+    try:
+        sequence = jam_solver(g, loads)
+        assert False
+    except ValueError as e:
+        assert str(e) == f"No path found between {1} and {5}"
+

--- a/tests/test_traffic_scheduling_problem.py
+++ b/tests/test_traffic_scheduling_problem.py
@@ -358,3 +358,16 @@ def test_loop_52():
          89: (42, 43), 97: (51, 52), 96: (50, 51), 95: (49, 50)}
     ], "something is wrong. All moves CAN happen at the same time."
 
+
+def test_simple_failed_path():
+    """ two colliding loads with no solution """
+    g = Graph()
+    for s, e in [(1, 2), (2, 3)]:
+        g.add_edge(s, e, 1, bidirectional=True)
+
+    loads = {1: [1, 3], 2: [3, 1]}
+
+    sequence = jam_solver(g, loads)
+
+    assert sequence is None
+


### PR DESCRIPTION
…g from empty list. Very basic test added. 

At present, an unsolvable graph will fail on trying to pop from an empty list. This commit raises an exception instead. 