### PR TITLE
Memoize and non-memoize to return same

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -598,6 +598,32 @@ def test_cached_graph():
     assert p1 == p2, (p1, p2)
 
 
+def test_cached_graph_no_path():
+    """
+    Returns for a cached graph should be the same as for an uncached graph.
+    [1] --> [2]    [3] --> [4]
+    """
+    g = Graph(from_list=[(1, 2, 1), (3, 4, 1)])
+
+    # for no path
+    d1, p1 = g.shortest_path(1, 4)
+    assert d1 == float("inf")
+    assert p1 == []
+
+    d2, p2 = g.shortest_path(1, 4, memoize=True)
+    assert d1 == d2
+    assert p1 == p2
+
+    # for same start and end
+    d1, p1 = g.shortest_path(1, 1)
+    assert d1 == 0
+    assert p1 == [1]
+
+    d2, p2 = g.shortest_path(1, 1, memoize=True)
+    assert d1 == d2
+    assert p1 == p2
+
+
 def test_cached_graph2():
     g = london_underground()
     seds = list(g.edges())


### PR DESCRIPTION
Prior to this memoize didn't return the same as non-memoized shortest_path searches. For a path request between the same object, or a path request between objects which aren't connected we should return with consistency whether we call memoize or not. 

I have also added these to the cache, because I see no reason that they shouldn't be cached.